### PR TITLE
fix: remove listing as core app

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -4,7 +4,7 @@ const config = {
     name: 'data-exchange',
     title: 'Data Exchange',
     minDHIS2Version: '2.39',
-    coreApp: true,
+    coreApp: false,
     entryPoints: {
         app: './src/app/index.js',
     },


### PR DESCRIPTION
Set to `coreApp: false` in d2.config.js to address `Only bundled apps may be declared as core apps` error in app management app on install.