### PR TITLE
fix: use contextPath from systemInfo for url [DHIS2-17288]

### DIFF
--- a/src/components/view/submit-modal/submit-modal.js
+++ b/src/components/view/submit-modal/submit-modal.js
@@ -143,14 +143,14 @@ const getReportText = (request) => {
 const ConfirmModalContent = ({ exchange, requests, onClose, onSubmit }) => {
     // this is very wordy, but did not have luck with i18nextscanner picking up from more compact versions...
     let reportTranslationsString
-    const { baseUrl } = useConfig()
+    const { systemInfo } = useConfig()
     const reportCount = requests.length
     const exchangeName = exchange?.displayName
     const exchangeURL =
         exchange?.target?.type === 'INTERNAL'
-            ? baseUrl
+            ? systemInfo?.contextPath
             : exchange?.target?.api?.url
-    const exchangeHostName = exchangeURL?.split('//')[1] // remove protocol
+    const exchangeHostName = exchangeURL?.split('//')[1] ?? exchangeURL // remove protocol
 
     if (exchange?.target?.type === 'INTERNAL') {
         if (requests.length > 1) {


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-17288

Now uses systemInfo.contextPath to display internal URL as baseUrl directly from useConfig can be a relative path.

**Before**
<img width="672" alt="image" src="https://github.com/dhis2/data-exchange-app/assets/18490902/f4acf989-a59f-43fd-b322-3efd2b39f6dc">


**After**
<img width="777" alt="image" src="https://github.com/dhis2/data-exchange-app/assets/18490902/17f86f94-7154-4cc6-ba9f-7597250f0f26">
