### PR TITLE
fix: remove request NONE id schemes [DHIS2-18013]

### DIFF
--- a/src/components/edit/exchange-update/__tests__/getExchangeValues.test.js
+++ b/src/components/edit/exchange-update/__tests__/getExchangeValues.test.js
@@ -1,0 +1,64 @@
+import { cleanUpRequests } from '../getExchangeValues.js'
+
+describe('cleanUpRequests', () => {
+    it('removes irrelevant properties', () => {
+        const originalRequests = [
+            {
+                name: 'a name',
+                visualization: 'a visualization',
+                dx: [],
+                pe: [],
+                ou: [],
+                filters: [],
+                inputIdScheme: 'UID',
+                outputDataElementIdScheme: 'UID',
+                outputOrgUnitIdScheme: 'UID',
+                outputIdScheme: 'UID',
+                outputDataItemIdScheme: 'UID',
+                dhis2: [],
+                team: 'platform',
+            },
+        ]
+        const expectedRequests = [
+            {
+                name: 'a name',
+                visualization: 'a visualization',
+                dx: [],
+                pe: [],
+                ou: [],
+                filters: [],
+                inputIdScheme: 'UID',
+                outputDataElementIdScheme: 'UID',
+                outputOrgUnitIdScheme: 'UID',
+                outputIdScheme: 'UID',
+                outputDataItemIdScheme: 'UID',
+            },
+        ]
+        expect(cleanUpRequests({ requests: originalRequests })).toEqual(
+            expectedRequests
+        )
+    })
+
+    it('only returns properties that are not null or undefined on the original', () => {
+        const originalRequests = [{ dx: [], pe: undefined }]
+        const expectedRequests = [{ dx: [] }]
+        expect(cleanUpRequests({ requests: originalRequests })).toEqual(
+            expectedRequests
+        )
+    })
+
+    it('removes ID schemes of value NONE (outputDataElementIdScheme, outputOrgUnitIdScheme, outputDataItemIdScheme)', () => {
+        const originalRequests = [
+            {
+                dx: [],
+                outputDataElementIdScheme: 'NONE',
+                outputOrgUnitIdScheme: 'NONE',
+                outputDataItemIdScheme: 'NONE',
+            },
+        ]
+        const expectedRequests = [{ dx: [] }]
+        expect(cleanUpRequests({ requests: originalRequests })).toEqual(
+            expectedRequests
+        )
+    })
+})

--- a/src/components/edit/exchange-update/getExchangeValues.js
+++ b/src/components/edit/exchange-update/getExchangeValues.js
@@ -4,15 +4,38 @@ import {
     AUTHENTICATION_TYPES,
 } from '../shared/index.js'
 
-const removeRequestIDSchemeValuesOfNONE = ({ requests }) => {
+// this filters out additional properties that are used by the app UI, but should not be sent to backend
+const validProperties = [
+    'name',
+    'visualization',
+    'dx',
+    'pe',
+    'ou',
+    'filters',
+    'inputIdScheme',
+    'outputDataElementIdScheme',
+    'outputOrgUnitIdScheme',
+    'outputIdScheme',
+    'outputDataItemIdScheme',
+]
+const copyRequestWithValidProperties = (request) =>
+    validProperties.reduce((requestCopy, prop) => {
+        if (request[prop]) {
+            requestCopy[prop] = request[prop]
+        }
+        return requestCopy
+    }, {})
+
+export const cleanUpRequests = ({ requests }) => {
     const idSchemeProps = [
-        'idScheme',
-        'dataElementIdScheme',
-        'orgUnitIdScheme',
-        'categoryOptionComboIdScheme',
+        'outputDataElementIdScheme',
+        'outputDataItemIdScheme',
+        'outputOrgUnitIdScheme',
     ]
     return requests.map((request) => {
-        const requestCopy = { ...request }
+        const requestCopy = copyRequestWithValidProperties(request)
+
+        // delete any ID Scheme prop with value of NONE
         for (const prop of idSchemeProps) {
             if (requestCopy[prop] === SCHEME_TYPES.none) {
                 delete requestCopy[prop]
@@ -78,7 +101,7 @@ const getTargetDetails = ({ values }) => {
 export const getExchangeValuesFromForm = ({ values, requests }) => ({
     name: values.name,
     target: getTargetDetails({ values }),
-    source: { requests: removeRequestIDSchemeValuesOfNONE({ requests }) },
+    source: { requests: cleanUpRequests({ requests }) },
 })
 
 const getIdSchemeValues = ({ exchangeInfo }) => {


### PR DESCRIPTION
This fixes a bug whereby ID Schemes for requests were being sent to the backend with "NONE" values (https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-18013). The backend excepted these "NONE" types and then the exchange wouldn't run.

The app was supposed to be filtering out "NONE" values, but I had the wrong ID scheme names defined, so this failed.

The requests were also being posted to the backend with some additional properties (e.g. dxInfo that contains metadata about the dx selected). These extra properties were ignored, but it made interpreting the payload a bit difficult, so I've updated the logic to filter out properties that are only relevant for the app.

I've added some unit tests and modified an existing add-page test to partly cover this. I think it would be good to add some additional dedicated tests for add page, edit page around request ID schemes, but I've created a separate ticket for that (https://dhis2.atlassian.net/browse/DHIS2-18015) as I wanted to prioritize fixing the bug here.