### PR TITLE
fix: persist update to personal access token [DHIS2-17382]

### DIFF
--- a/src/components/edit/exchange-update/useUpdateExchange.js
+++ b/src/components/edit/exchange-update/useUpdateExchange.js
@@ -29,6 +29,7 @@ const getJsonPatch = ({ formattedValues, form, requestsTouched }) => {
     const targetFields = [
         'type',
         'authentication',
+        'accessToken',
         'url',
         'username',
         ...targetIdSchemesFields,


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-17382

`accessToken` was missing from fields checked to persist update.

**Before**: updating access token did not trigger patch to update.
**After**: updating access token triggers patch update.

Tested manually and added an automated test.


