### PR TITLE
fix: do not require unneeded auth updates  [DHIS2-18412]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-10-11T11:26:20.632Z\n"
-"PO-Revision-Date: 2024-10-11T11:26:20.633Z\n"
+"POT-Creation-Date: 2025-03-11T15:50:18.656Z\n"
+"PO-Revision-Date: 2025-03-11T15:50:18.656Z\n"
 
 msgid "Advanced options"
 msgstr "Advanced options"
@@ -136,31 +136,15 @@ msgstr "Edit exchange"
 msgid "Could not save"
 msgstr "Could not save"
 
-msgid "Editing the target setup will require you to reenter authentication details."
-msgstr "Editing the target setup will require you to reenter authentication details."
-
 msgid ""
-"Editing the input ID scheme options will require you to reenter "
-"authentication details."
+"You will need to reenter authentication details (password, api token) if "
+"you edit this information"
 msgstr ""
-"Editing the input ID scheme options will require you to reenter "
-"authentication details."
+"You will need to reenter authentication details (password, api token) if "
+"you edit this information"
 
-msgid ""
-"Editing the advanced options will require you to reenter authentication "
-"details."
-msgstr ""
-"Editing the advanced options will require you to reenter authentication "
-"details."
-
-msgid "Edit target setup"
-msgstr "Edit target setup"
-
-msgid "Edit input ID scheme options"
-msgstr "Edit input ID scheme options"
-
-msgid "Edit advanced options"
-msgstr "Edit advanced options"
+msgid "Edit authentication details"
+msgstr "Edit authentication details"
 
 msgid "{{firstOuName}} and {{ouLength}} others"
 msgstr "{{firstOuName}} and {{ouLength}} others"
@@ -512,6 +496,63 @@ msgstr ""
 
 msgid "New line list"
 msgstr "New line list"
+
+msgid "Pivot table"
+msgstr "Pivot table"
+
+msgid "Area"
+msgstr "Area"
+
+msgid "Stacked area"
+msgstr "Stacked area"
+
+msgid "Bar"
+msgstr "Bar"
+
+msgid "Stacked bar"
+msgstr "Stacked bar"
+
+msgid "Column"
+msgstr "Column"
+
+msgid "Year over year (column)"
+msgstr "Year over year (column)"
+
+msgid "Stacked column"
+msgstr "Stacked column"
+
+msgid "Gauge"
+msgstr "Gauge"
+
+msgid "Line"
+msgstr "Line"
+
+msgid "Line list"
+msgstr "Line list"
+
+msgid "Year over year (line)"
+msgstr "Year over year (line)"
+
+msgid "Pie"
+msgstr "Pie"
+
+msgid "Radar"
+msgstr "Radar"
+
+msgid "Scatter"
+msgstr "Scatter"
+
+msgid "Single value"
+msgstr "Single value"
+
+msgid "Outlier table"
+msgstr "Outlier table"
+
+msgid "All types"
+msgstr "All types"
+
+msgid "All charts"
+msgstr "All charts"
 
 msgid "None (follows {{defaultIDSchemeName}})"
 msgstr "None (follows {{defaultIDSchemeName}})"

--- a/src/components/edit/exchange-update/__tests__/useUpdateExchange.test.js
+++ b/src/components/edit/exchange-update/__tests__/useUpdateExchange.test.js
@@ -171,4 +171,88 @@ describe('getJsonPatch', () => {
         ]
         expect(results).toEqual(expected)
     })
+
+    it('creates ngrouped patch when changing type (pat)', () => {
+        const FORMATTED_VALUES = {
+            name: 'newly made external',
+            target: {
+                type: 'EXTERNAL',
+                request: {
+                    idScheme: 'CODE',
+                    dataElementIdScheme: 'ATTRIBUTE:l1VmqIHKk6t',
+                    categoryOptionComboIdScheme: 'UID',
+                    skipAudit: true,
+                    dryRun: false,
+                    importStrategy: 'UPDATE',
+                },
+                api: {
+                    url: 'http://www.external.dhis2.org',
+                    accessToken: 'new_access_token',
+                    authentication: 'PAT',
+                },
+            },
+            source: {
+                requests: [
+                    {
+                        name: 'cat',
+                        dx: ['fbfJHSPpUQD'],
+                        pe: ['LAST_MONTH'],
+                        ou: ['fdc6uOvgoji'],
+                        filters: [],
+                        inputIdScheme: 'UID',
+                        outputIdScheme: 'UID',
+                    },
+                ],
+            },
+        }
+
+        const dirtyFields = {
+            name: true,
+            url: true,
+            accessToken: true,
+            target_idScheme: true,
+            target_dataElementIdScheme: true,
+            target_orgUnitIdScheme: true,
+            target_dataElementIdScheme_attribute: true,
+            dryRun: true,
+            importStrategy: true,
+            type: true,
+        }
+        const FORM = {
+            getState: () => ({
+                dirtyFields,
+            }),
+        }
+
+        const results = getJsonPatch({
+            formattedValues: FORMATTED_VALUES,
+            form: FORM,
+            requestsTouched: false,
+        })
+
+        const expected = [
+            { op: 'add', path: '/name', value: 'newly made external' },
+
+            {
+                op: 'add',
+                path: '/target',
+                value: {
+                    api: {
+                        accessToken: 'new_access_token',
+                        url: 'http://www.external.dhis2.org',
+                    },
+                    request: {
+                        idScheme: 'CODE',
+                        dataElementIdScheme: 'ATTRIBUTE:l1VmqIHKk6t',
+                        categoryOptionComboIdScheme: 'UID',
+                        skipAudit: true,
+                        dryRun: false,
+                        importStrategy: 'UPDATE',
+                    },
+                    type: 'EXTERNAL',
+                },
+            },
+        ]
+        expect(results).toEqual(expected)
+    })
 })

--- a/src/components/edit/exchange-update/__tests__/useUpdateExchange.test.js
+++ b/src/components/edit/exchange-update/__tests__/useUpdateExchange.test.js
@@ -1,0 +1,174 @@
+import { getJsonPatch } from '../useUpdateExchange.js'
+
+describe('getJsonPatch', () => {
+    it('creates individual patch values for target, api, and grouped patch for request (basic)', () => {
+        const FORMATTED_VALUES = {
+            name: 'new name external',
+            target: {
+                type: 'EXTERNAL',
+                request: {
+                    idScheme: 'CODE',
+                    dataElementIdScheme: 'ATTRIBUTE:l1VmqIHKk6t',
+                    categoryOptionComboIdScheme: 'UID',
+                    skipAudit: true,
+                    dryRun: false,
+                    importStrategy: 'UPDATE',
+                },
+                api: {
+                    url: 'http://www.external.dhis2.org',
+                    username: 'new_username',
+                    password: 'new_password',
+                },
+            },
+            source: {
+                requests: [
+                    {
+                        name: 'cat',
+                        dx: ['fbfJHSPpUQD'],
+                        pe: ['LAST_MONTH'],
+                        ou: ['fdc6uOvgoji'],
+                        filters: [],
+                        inputIdScheme: 'UID',
+                        outputIdScheme: 'UID',
+                    },
+                ],
+            },
+        }
+
+        const dirtyFields = {
+            name: true,
+            url: true,
+            username: true,
+            password: true,
+            target_idScheme: true,
+            target_dataElementIdScheme: true,
+            target_orgUnitIdScheme: true,
+            target_dataElementIdScheme_attribute: true,
+            dryRun: true,
+            importStrategy: true,
+        }
+        const FORM = {
+            getState: () => ({
+                dirtyFields,
+            }),
+        }
+
+        const results = getJsonPatch({
+            formattedValues: FORMATTED_VALUES,
+            form: FORM,
+            requestsTouched: false,
+        })
+
+        const expected = [
+            { op: 'add', path: '/name', value: 'new name external' },
+            {
+                op: 'add',
+                path: '/target/api/url',
+                value: 'http://www.external.dhis2.org',
+            },
+            { op: 'add', path: '/target/api/username', value: 'new_username' },
+            { op: 'add', path: '/target/api/password', value: 'new_password' },
+            { op: 'remove', path: '/target/api/accessToken' },
+            {
+                op: 'add',
+                path: '/target/request',
+                value: {
+                    idScheme: 'CODE',
+                    dataElementIdScheme: 'ATTRIBUTE:l1VmqIHKk6t',
+                    categoryOptionComboIdScheme: 'UID',
+                    skipAudit: true,
+                    dryRun: false,
+                    importStrategy: 'UPDATE',
+                },
+            },
+        ]
+        expect(results).toEqual(expected)
+    })
+
+    it('creates individual patch values for target, api, and grouped patch for request (pat)', () => {
+        const FORMATTED_VALUES = {
+            name: 'new name external',
+            target: {
+                type: 'EXTERNAL',
+                request: {
+                    idScheme: 'CODE',
+                    dataElementIdScheme: 'ATTRIBUTE:l1VmqIHKk6t',
+                    categoryOptionComboIdScheme: 'UID',
+                    skipAudit: true,
+                    dryRun: false,
+                    importStrategy: 'UPDATE',
+                },
+                api: {
+                    url: 'http://www.external.dhis2.org',
+                    accessToken: 'new_access_token',
+                    authentication: 'PAT',
+                },
+            },
+            source: {
+                requests: [
+                    {
+                        name: 'cat',
+                        dx: ['fbfJHSPpUQD'],
+                        pe: ['LAST_MONTH'],
+                        ou: ['fdc6uOvgoji'],
+                        filters: [],
+                        inputIdScheme: 'UID',
+                        outputIdScheme: 'UID',
+                    },
+                ],
+            },
+        }
+
+        const dirtyFields = {
+            name: true,
+            url: true,
+            accessToken: true,
+            target_idScheme: true,
+            target_dataElementIdScheme: true,
+            target_orgUnitIdScheme: true,
+            target_dataElementIdScheme_attribute: true,
+            dryRun: true,
+            importStrategy: true,
+        }
+        const FORM = {
+            getState: () => ({
+                dirtyFields,
+            }),
+        }
+
+        const results = getJsonPatch({
+            formattedValues: FORMATTED_VALUES,
+            form: FORM,
+            requestsTouched: false,
+        })
+
+        const expected = [
+            { op: 'add', path: '/name', value: 'new name external' },
+            {
+                op: 'add',
+                path: '/target/api/url',
+                value: 'http://www.external.dhis2.org',
+            },
+            {
+                op: 'add',
+                path: '/target/api/accessToken',
+                value: 'new_access_token',
+            },
+            { op: 'remove', path: '/target/api/username' },
+            { op: 'remove', path: '/target/api/password' },
+            {
+                op: 'add',
+                path: '/target/request',
+                value: {
+                    idScheme: 'CODE',
+                    dataElementIdScheme: 'ATTRIBUTE:l1VmqIHKk6t',
+                    categoryOptionComboIdScheme: 'UID',
+                    skipAudit: true,
+                    dryRun: false,
+                    importStrategy: 'UPDATE',
+                },
+            },
+        ]
+        expect(results).toEqual(expected)
+    })
+})

--- a/src/components/edit/exchange-update/advanced-options.js
+++ b/src/components/edit/exchange-update/advanced-options.js
@@ -71,7 +71,6 @@ export const AdvancedOptions = () => {
                         'Improves performance at the cost of ability to audit changes.'
                     )}
                     component={CheckboxFieldFF}
-                    // disabled={editTargetSetupDisabled}
                 />
             </div>
             <div className={styles.subsectionField1000}>

--- a/src/components/edit/exchange-update/advanced-options.js
+++ b/src/components/edit/exchange-update/advanced-options.js
@@ -14,7 +14,6 @@ import {
     TogglableSubsection,
 } from '../shared/index.js'
 import styles from './advanced-options.module.css'
-import { EnableExternalEditWarning } from './external-edit-warning.js'
 
 const Label = ({ label, prefix, type }) => {
     if (!prefix) {
@@ -43,10 +42,7 @@ Label.propTypes = {
 
 const { Field } = ReactFinalForm
 
-export const AdvancedOptions = ({
-    editTargetSetupDisabled,
-    setEditTargetSetupDisabled,
-}) => {
+export const AdvancedOptions = () => {
     const { skipAuditDryRunImportStrategyAvailable } = useFeatureToggleContext()
 
     const [advancedOpen, setAdvancedOpen] = useState(false)
@@ -64,11 +60,6 @@ export const AdvancedOptions = ({
             onTextClick={toggleAdvancedSection}
             text={i18n.t('Advanced options')}
         >
-            <EnableExternalEditWarning
-                editTargetSetupDisabled={editTargetSetupDisabled}
-                setEditTargetSetupDisabled={setEditTargetSetupDisabled}
-                sectionName="advancedOptions"
-            />
             <div className={styles.subsectionField1000}>
                 <Field
                     name="skipAudit"
@@ -80,7 +71,7 @@ export const AdvancedOptions = ({
                         'Improves performance at the cost of ability to audit changes.'
                     )}
                     component={CheckboxFieldFF}
-                    disabled={editTargetSetupDisabled}
+                    // disabled={editTargetSetupDisabled}
                 />
             </div>
             <div className={styles.subsectionField1000}>
@@ -92,7 +83,6 @@ export const AdvancedOptions = ({
                         'A dry run tests the import settings without importing any data.'
                     )}
                     component={CheckboxFieldFF}
-                    disabled={editTargetSetupDisabled}
                 />
             </div>
             <div className={styles.subsectionField1000}>
@@ -114,7 +104,6 @@ export const AdvancedOptions = ({
                                     />
                                 }
                                 value={iso.value}
-                                disabled={editTargetSetupDisabled}
                             />
                         ))}
                     </div>
@@ -122,9 +111,4 @@ export const AdvancedOptions = ({
             </div>
         </TogglableSubsection>
     )
-}
-
-AdvancedOptions.propTypes = {
-    editTargetSetupDisabled: PropTypes.bool,
-    setEditTargetSetupDisabled: PropTypes.func,
 }

--- a/src/components/edit/exchange-update/exchange-form-contents.js
+++ b/src/components/edit/exchange-update/exchange-form-contents.js
@@ -128,13 +128,6 @@ export const ExchangeFormContents = React.memo(
                         text={i18n.t('Target setup')}
                         dataTest="target-setup"
                     >
-                        <EnableExternalEditWarning
-                            editTargetSetupDisabled={editTargetSetupDisabled}
-                            setEditTargetSetupDisabled={
-                                setEditTargetSetupDisabled
-                            }
-                            sectionName="targetSetup"
-                        />
                         <div
                             className={styles.subsectionField600}
                             data-test="exchange-url"
@@ -145,13 +138,20 @@ export const ExchangeFormContents = React.memo(
                                 helpText={i18n.t(
                                     'The URL of the target instance or data warehouse.'
                                 )}
-                                disabled={editTargetSetupDisabled}
                                 component={InputFieldFF}
                                 validate={hasValue}
                             />
                         </div>
 
                         <div>
+                            <EnableExternalEditWarning
+                                editTargetSetupDisabled={
+                                    editTargetSetupDisabled
+                                }
+                                setEditTargetSetupDisabled={
+                                    setEditTargetSetupDisabled
+                                }
+                            />
                             <FieldContainer
                                 label={i18n.t('Authentication method')}
                             >
@@ -266,27 +266,18 @@ export const ExchangeFormContents = React.memo(
                     className={styles.idSchemeSection}
                 >
                     <>
-                        <EnableExternalEditWarning
-                            editTargetSetupDisabled={editTargetSetupDisabled}
-                            setEditTargetSetupDisabled={
-                                setEditTargetSetupDisabled
-                            }
-                            sectionName="idSchemes"
-                        />
                         <SchemeSelector
                             label={i18n.t('Input general ID scheme')}
                             description={i18n.t(
                                 'Used as the default ID scheme for all items. If the chosen scheme is not available for an item, it will fall back to using ID.'
                             )}
                             name="target_idScheme"
-                            disabled={editTargetSetupDisabled}
                             dataTest="general-id-scheme-selector"
                         />
                         <SchemeSelector
                             label={i18n.t('Input data element ID scheme')}
                             description={i18n.t('Applies to data elements.')}
                             name="target_dataElementIdScheme"
-                            disabled={editTargetSetupDisabled}
                             canBeNone={true}
                             defaultIDSchemeName={i18n.t(
                                 'Input general ID scheme'
@@ -299,7 +290,6 @@ export const ExchangeFormContents = React.memo(
                                 'Applies to organisation units.'
                             )}
                             name="target_orgUnitIdScheme"
-                            disabled={editTargetSetupDisabled}
                             canBeNone={true}
                             defaultIDSchemeName={i18n.t(
                                 'Input general ID scheme'
@@ -314,7 +304,6 @@ export const ExchangeFormContents = React.memo(
                                 'Applies to category option combos.'
                             )}
                             name="target_categoryOptionComboIdScheme"
-                            disabled={editTargetSetupDisabled}
                             canBeNone={true}
                             defaultIDSchemeName={i18n.t(
                                 'Input general ID scheme'
@@ -323,10 +312,7 @@ export const ExchangeFormContents = React.memo(
                         />
                     </>
                 </Subsection>
-                <AdvancedOptions
-                    editTargetSetupDisabled={editTargetSetupDisabled}
-                    setEditTargetSetupDisabled={setEditTargetSetupDisabled}
-                />
+                <AdvancedOptions />
             </>
         )
     }

--- a/src/components/edit/exchange-update/external-edit-warning.js
+++ b/src/components/edit/exchange-update/external-edit-warning.js
@@ -5,28 +5,9 @@ import React from 'react'
 import { Warning } from '../../common/index.js'
 import styles from './external-edit-warning.module.css'
 
-const sectionNameWarning = {
-    targetSetup: i18n.t(
-        'Editing the target setup will require you to reenter authentication details.'
-    ),
-    idSchemes: i18n.t(
-        'Editing the input ID scheme options will require you to reenter authentication details.'
-    ),
-    advancedOptions: i18n.t(
-        'Editing the advanced options will require you to reenter authentication details.'
-    ),
-}
-
-const sectionNameEdit = {
-    targetSetup: i18n.t('Edit target setup'),
-    idSchemes: i18n.t('Edit input ID scheme options'),
-    advancedOptions: i18n.t('Edit advanced options'),
-}
-
 export const EnableExternalEditWarning = ({
     editTargetSetupDisabled,
     setEditTargetSetupDisabled,
-    sectionName,
 }) => {
     if (!editTargetSetupDisabled) {
         return null
@@ -34,13 +15,17 @@ export const EnableExternalEditWarning = ({
 
     return (
         <Warning>
-            <div>{sectionNameWarning[sectionName ?? 'targetSetup']}</div>
+            <div>
+                {i18n.t(
+                    'You will need to reenter authentication details (password, api token) if you edit this information'
+                )}
+            </div>
             <Button
                 className={styles.editWarningButton}
                 small
                 onClick={() => setEditTargetSetupDisabled(false)}
             >
-                {sectionNameEdit[sectionName ?? 'targetSetup']}
+                {i18n.t('Edit authentication details')}
             </Button>
         </Warning>
     )
@@ -48,6 +33,5 @@ export const EnableExternalEditWarning = ({
 
 EnableExternalEditWarning.propTypes = {
     editTargetSetupDisabled: PropTypes.bool,
-    sectionName: PropTypes.string,
     setEditTargetSetupDisabled: PropTypes.func,
 }

--- a/src/components/edit/exchange-update/getExchangeValues.js
+++ b/src/components/edit/exchange-update/getExchangeValues.js
@@ -144,9 +144,10 @@ export const getInitialValuesFromExchange = ({
 }) => ({
     name: exchangeInfo.name,
     type: exchangeInfo.target?.type,
-    authentication: exchangeInfo.target?.api?.accessToken
-        ? AUTHENTICATION_TYPES.pat
-        : AUTHENTICATION_TYPES.basic,
+    authentication:
+        !exchangeInfo?.target?.api || exchangeInfo.target?.api?.username
+            ? AUTHENTICATION_TYPES.basic
+            : AUTHENTICATION_TYPES.pat,
     url: exchangeInfo.target?.api?.url,
     username: exchangeInfo.target?.api?.username,
     ...getIdSchemeValues({ exchangeInfo }),

--- a/src/components/edit/exchange-update/getExchangeValues.js
+++ b/src/components/edit/exchange-update/getExchangeValues.js
@@ -87,25 +87,13 @@ const getTargetDetails = ({ values }) => {
     // upate to include api
     target.api = {
         url: values.url,
+        accessToken: values.accessToken,
+        username: values.username,
+        password: values.password,
+        authentication: values.authentication, // this will not actually be sent to backend
     }
 
-    if (values.authentication === AUTHENTICATION_TYPES.pat) {
-        return {
-            ...target,
-            api: {
-                ...target.api,
-                accessToken: values.accessToken,
-            },
-        }
-    }
-    return {
-        ...target,
-        api: {
-            ...target.api,
-            username: values.username,
-            password: values.password,
-        },
-    }
+    return target
 }
 
 export const getExchangeValuesFromForm = ({ values, requests }) => ({
@@ -156,9 +144,9 @@ export const getInitialValuesFromExchange = ({
 }) => ({
     name: exchangeInfo.name,
     type: exchangeInfo.target?.type,
-    authentication: exchangeInfo.target?.api?.username
-        ? AUTHENTICATION_TYPES.basic
-        : AUTHENTICATION_TYPES.pat,
+    authentication: exchangeInfo.target?.api?.accessToken
+        ? AUTHENTICATION_TYPES.pat
+        : AUTHENTICATION_TYPES.basic,
     url: exchangeInfo.target?.api?.url,
     username: exchangeInfo.target?.api?.username,
     ...getIdSchemeValues({ exchangeInfo }),

--- a/src/components/edit/exchange-update/useUpdateExchange.js
+++ b/src/components/edit/exchange-update/useUpdateExchange.js
@@ -57,6 +57,9 @@ export const getJsonPatch = ({ formattedValues, form, requestsTouched }) => {
 
     // if target type changes, we need to replace everything on the target
     if (modifiedFields.has('type')) {
+        // this is not avalid for backend
+        delete formattedValues?.target?.api?.authentication
+
         changes.push(
             getChange({
                 field: 'target',

--- a/src/components/edit/exchange-update/useUpdateExchange.js
+++ b/src/components/edit/exchange-update/useUpdateExchange.js
@@ -1,5 +1,6 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import { useCallback, useState } from 'react'
+import { AUTHENTICATION_TYPES, EXCHANGE_TYPES } from '../shared/constants.js'
 import { getExchangeValuesFromForm } from './getExchangeValues.js'
 
 const getChange = ({ field, value }) => ({
@@ -8,7 +9,12 @@ const getChange = ({ field, value }) => ({
     value: value ?? null,
 })
 
-const getJsonPatch = ({ formattedValues, form, requestsTouched }) => {
+const getDelete = ({ field }) => ({
+    op: 'remove',
+    path: '/' + field,
+})
+
+export const getJsonPatch = ({ formattedValues, form, requestsTouched }) => {
     const changes = []
     const modifiedFields = new Set(Object.keys(form.getState().dirtyFields))
 
@@ -26,21 +32,74 @@ const getJsonPatch = ({ formattedValues, form, requestsTouched }) => {
     const targetIdSchemesFields = targetIdSchemes.reduce((allNames, scheme) => {
         return [...allNames, `target_${scheme}`, `target_${scheme}_attribute`]
     }, [])
-    const targetFields = [
-        'type',
-        'authentication',
-        'accessToken',
-        'url',
-        'username',
+
+    const targetApiFieldsBasic = ['username', 'password']
+    const targetApiFieldsPAT = ['accessToken']
+    const targetApiFields =
+        formattedValues?.target?.api?.authentication ===
+        AUTHENTICATION_TYPES.pat
+            ? targetApiFieldsPAT
+            : targetApiFieldsBasic
+    const removeApiFields =
+        formattedValues.target.type === EXCHANGE_TYPES.internal
+            ? []
+            : formattedValues?.target?.api?.authentication ===
+              AUTHENTICATION_TYPES.pat
+            ? targetApiFieldsBasic
+            : targetApiFieldsPAT
+
+    const targetRequestFields = [
         'dryRun',
         'skipAudit',
         'importStrategy',
         ...targetIdSchemesFields,
     ]
-    if (targetFields.some((tf) => modifiedFields.has(tf))) {
+
+    // if target type changes, we need to replace everything on the target
+    if (modifiedFields.has('type')) {
         changes.push(
-            getChange({ field: 'target', value: formattedValues.target })
+            getChange({
+                field: 'target',
+                value: formattedValues.target,
+            })
         )
+    } else {
+        if (modifiedFields.has('url')) {
+            changes.push(
+                getChange({
+                    field: 'target/api/url',
+                    value: formattedValues.target.api.url,
+                })
+            )
+        }
+
+        targetApiFields.forEach((tf) => {
+            if (modifiedFields.has(tf)) {
+                changes.push(
+                    getChange({
+                        field: `target/api/${tf}`,
+                        value: formattedValues.target.api[tf],
+                    })
+                )
+            }
+        })
+
+        removeApiFields.forEach((tf) => {
+            changes.push(
+                getDelete({
+                    field: `target/api/${tf}`,
+                })
+            )
+        })
+
+        if (targetRequestFields.some((tf) => modifiedFields.has(tf))) {
+            changes.push(
+                getChange({
+                    field: 'target/request',
+                    value: formattedValues.target.request,
+                })
+            )
+        }
     }
 
     if (requestsTouched) {

--- a/src/pages/editItem.test.js
+++ b/src/pages/editItem.test.js
@@ -319,12 +319,13 @@ describe('<EditItem/>', () => {
         )
     })
 
-    it('can not edit an external exchange target setup if not explicitly specified', async () => {
+    it('can edit url, but not authentication details for an external exchange without confirming to edit authentication', async () => {
         const request = testRequest()
         const dataExchange = testDataExchange({
             requests: [request],
             targetType: 'EXTERNAL',
         })
+        dataExchange.target.api.accessToken = 'fake_access_token'
 
         const { screen } = setUp(<EditItem />, {
             userContext: testUserContext({ canAddExchange: true }),
@@ -338,10 +339,29 @@ describe('<EditItem/>', () => {
         const exchangeURLInput = within(
             await screen.findByTestId('exchange-url')
         ).getByLabelText('Target URL')
-        expect(exchangeURLInput).toBeDisabled()
+        expect(exchangeURLInput).not.toBeDisabled()
+
+        fireEvent.input(exchangeURLInput, {
+            target: { value: 'newExchangeUrl.com' },
+        })
+
+        const tokenInput = within(
+            screen.getByTestId('exchange-auth-pat')
+        ).getByLabelText('Access token')
+        expect(tokenInput).toBeDisabled()
+
+        within(screen.getByTestId('edit-item-footer'))
+            .getByText('Save exchange')
+            .click()
+
+        await waitFor(() =>
+            expect(
+                screen.getByTestId('saving-exchange-loader')
+            ).toBeInTheDocument()
+        )
     })
 
-    it('can edit an external exchange target setup if explicitly specified', async () => {
+    it('can edit an external exchange authentication setup if explicitly specified', async () => {
         const request = testRequest()
         const dataExchange = testDataExchange({
             requests: [request],
@@ -359,7 +379,7 @@ describe('<EditItem/>', () => {
 
         within(screen.getByTestId('target-setup'))
             .queryByRole('button', {
-                name: 'Edit target setup',
+                name: 'Edit authentication details',
             })
             .click()
 
@@ -394,7 +414,7 @@ describe('<EditItem/>', () => {
         )
     })
 
-    it('can not edit an external exchange input id scheme options if not explicitly specified', async () => {
+    it('can edit an external exchange input id scheme options without confirming to edit authentication details', async () => {
         const request = testRequest()
         const dataExchange = testDataExchange({
             requests: [request],
@@ -409,148 +429,27 @@ describe('<EditItem/>', () => {
         expect(
             await screen.findByTestId('add-exchange-title')
         ).toHaveTextContent('Edit exchange')
-
-        const generalIdSchemeRadio = within(
-            screen.getByTestId('general-id-scheme-selector')
-        ).getAllByRole('radio')
-        generalIdSchemeRadio.map((r) => expect(r).toBeDisabled())
-
-        const elementIdSchemeRadio = within(
-            screen.getByTestId('element-id-scheme-selector')
-        ).getAllByRole('radio')
-        elementIdSchemeRadio.map((r) => expect(r).toBeDisabled())
-
-        const orgUnitIdSchemeRadio = within(
-            screen.getByTestId('org-unit-id-scheme-selector')
-        ).getAllByRole('radio')
-        orgUnitIdSchemeRadio.map((r) => expect(r).toBeDisabled())
-
-        const categoryOptionComboSchemeRadio = within(
-            screen.getByTestId('category-option-combo-scheme-selector')
-        ).getAllByRole('radio')
-        categoryOptionComboSchemeRadio.map((r) => expect(r).toBeDisabled())
-    })
-
-    it('can not edit an external exchange target input id scheme options if explicitly specified but auth info is not re-entered ', async () => {
-        const request = testRequest()
-        const dataExchange = testDataExchange({
-            requests: [request],
-            targetType: 'EXTERNAL',
-            externalURL: 'a/url',
-        })
-        const { screen } = setUp(<EditItem />, {
-            userContext: testUserContext({ canAddExchange: true }),
-            dataExchange,
-        })
-
-        expect(
-            await screen.findByTestId('add-exchange-title')
-        ).toHaveTextContent('Edit exchange')
-
-        const editButton = await screen.findByRole('button', {
-            name: 'Edit input ID scheme options',
-        })
-
-        editButton.click()
 
         const generalIdSchemeRadio = within(
             screen.getByTestId('general-id-scheme-selector')
         ).getAllByRole('radio')
         generalIdSchemeRadio.map((r) => expect(r).not.toBeDisabled())
-        generalIdSchemeRadio[1].click()
 
         const elementIdSchemeRadio = within(
             screen.getByTestId('element-id-scheme-selector')
         ).getAllByRole('radio')
         elementIdSchemeRadio.map((r) => expect(r).not.toBeDisabled())
-        elementIdSchemeRadio[1].click()
 
         const orgUnitIdSchemeRadio = within(
             screen.getByTestId('org-unit-id-scheme-selector')
         ).getAllByRole('radio')
         orgUnitIdSchemeRadio.map((r) => expect(r).not.toBeDisabled())
-        orgUnitIdSchemeRadio[1].click()
 
         const categoryOptionComboSchemeRadio = within(
             screen.getByTestId('category-option-combo-scheme-selector')
         ).getAllByRole('radio')
         categoryOptionComboSchemeRadio.map((r) => expect(r).not.toBeDisabled())
         categoryOptionComboSchemeRadio[1].click()
-
-        within(screen.getByTestId('edit-item-footer'))
-            .getByText('Save exchange')
-            .click()
-
-        const exchangeAutheInputWarning = within(
-            screen.getByTestId('exchange-auth-pat')
-        ).getByTestId('dhis2-uiwidgets-inputfield-validation')
-        expect(exchangeAutheInputWarning).toBeInTheDocument()
-        expect(exchangeAutheInputWarning).toHaveTextContent(
-            'Please provide a value'
-        )
-        await waitFor(() =>
-            expect(
-                screen.queryByTestId('saving-exchange-loader')
-            ).not.toBeInTheDocument()
-        )
-    })
-
-    it('can edit an external exchange target input id scheme options if explicitly specified and auth info is re-entered', async () => {
-        const request = testRequest()
-        const dataExchange = testDataExchange({
-            requests: [request],
-            targetType: 'EXTERNAL',
-            externalURL: 'a/url',
-        })
-        const { screen } = setUp(<EditItem />, {
-            userContext: testUserContext({ canAddExchange: true }),
-            dataExchange,
-        })
-
-        expect(
-            await screen.findByTestId('add-exchange-title')
-        ).toHaveTextContent('Edit exchange')
-
-        const editButton = await screen.findByRole('button', {
-            name: 'Edit input ID scheme options',
-        })
-
-        editButton.click()
-
-        const generalIdSchemeRadio = within(
-            screen.getByTestId('general-id-scheme-selector')
-        ).getAllByRole('radio')
-        generalIdSchemeRadio.map((r) => expect(r).not.toBeDisabled())
-        generalIdSchemeRadio[1].click()
-
-        const elementIdSchemeRadio = within(
-            screen.getByTestId('element-id-scheme-selector')
-        ).getAllByRole('radio')
-        elementIdSchemeRadio.map((r) => expect(r).not.toBeDisabled())
-        elementIdSchemeRadio[1].click()
-
-        const orgUnitIdSchemeRadio = within(
-            screen.getByTestId('org-unit-id-scheme-selector')
-        ).getAllByRole('radio')
-        orgUnitIdSchemeRadio.map((r) => expect(r).not.toBeDisabled())
-        orgUnitIdSchemeRadio[1].click()
-
-        const categoryOptionComboSchemeRadio = within(
-            screen.getByTestId('category-option-combo-scheme-selector')
-        ).getAllByRole('radio')
-        categoryOptionComboSchemeRadio.map((r) => expect(r).not.toBeDisabled())
-        categoryOptionComboSchemeRadio[1].click()
-
-        const authRadio = within(
-            screen.getByTestId('exchange-auth-method')
-        ).getAllByRole('radio')
-        expect(authRadio[1].getAttribute('value')).toEqual('PAT')
-        authRadio[1].click()
-
-        const tokenInput = within(
-            screen.getByTestId('exchange-auth-pat')
-        ).getByLabelText('Access token')
-        fireEvent.input(tokenInput, { target: { value: 'exchangePAT' } })
 
         within(screen.getByTestId('edit-item-footer'))
             .getByText('Save exchange')
@@ -558,8 +457,8 @@ describe('<EditItem/>', () => {
 
         await waitFor(() =>
             expect(
-                screen.getByTestId('saving-exchange-loader')
-            ).toBeInTheDocument()
+                screen.queryByTestId('saving-exchange-loader')
+            ).not.toBeInTheDocument()
         )
     })
 
@@ -696,12 +595,9 @@ describe('<EditItem/>', () => {
         const expectedPayload = [
             {
                 op: 'add',
-                path: '/target',
+                path: '/target/request',
                 value: {
-                    type: 'INTERNAL',
-                    request: {
-                        idScheme: 'UID',
-                    },
+                    idScheme: 'UID',
                 },
             },
         ]
@@ -758,15 +654,12 @@ describe('<EditItem/>', () => {
         const expectedPayload = [
             {
                 op: 'add',
-                path: '/target',
+                path: '/target/request',
                 value: {
-                    type: 'INTERNAL',
-                    request: {
-                        categoryOptionComboIdScheme: 'ATTRIBUTE:snorkmaiden',
-                        dataElementIdScheme: 'UID',
-                        idScheme: 'UID',
-                        orgUnitIdScheme: 'CODE',
-                    },
+                    categoryOptionComboIdScheme: 'ATTRIBUTE:snorkmaiden',
+                    dataElementIdScheme: 'UID',
+                    idScheme: 'UID',
+                    orgUnitIdScheme: 'CODE',
                 },
             },
         ]
@@ -775,7 +668,7 @@ describe('<EditItem/>', () => {
         expect(patchExchange).toHaveBeenCalledWith(expectedPayload)
     })
 
-    it('posts change to target when access token is updated', async () => {
+    it('posts change to target when password is updated', async () => {
         const user = userEvent.setup()
         const request = testRequest()
         const dataExchange = testDataExchange({
@@ -783,6 +676,8 @@ describe('<EditItem/>', () => {
             targetType: 'EXTERNAL',
             externalURL: 'a/url',
         })
+        dataExchange.target.api.username = 'dog'
+        dataExchange.target.api.password = 'cat'
 
         const { screen } = setUp(<EditItem />, {
             userContext: testUserContext({ canAddExchange: true }),
@@ -794,15 +689,15 @@ describe('<EditItem/>', () => {
         const confirmEditButton = within(
             screen.getByTestId('target-setup')
         ).queryByRole('button', {
-            name: 'Edit target setup',
+            name: 'Edit authentication details',
         })
 
         await user.click(confirmEditButton)
 
-        const patInput = within(
-            screen.getByTestId('exchange-auth-pat')
-        ).getByLabelText('Access token')
-        await user.type(patInput, 'fake_pat')
+        const passwordInput = within(
+            screen.getByTestId('exchange-auth-basic')
+        ).getByLabelText('Password')
+        await user.type(passwordInput, 'dog_password')
 
         const saveExchange = within(
             screen.getByTestId('edit-item-footer')
@@ -812,14 +707,12 @@ describe('<EditItem/>', () => {
         const expectedPayload = [
             {
                 op: 'add',
-                path: '/target',
-                value: {
-                    type: 'EXTERNAL',
-                    request: {
-                        idScheme: 'UID',
-                    },
-                    api: { url: 'a/url', accessToken: 'fake_pat' },
-                },
+                path: '/target/api/password',
+                value: 'dog_password',
+            },
+            {
+                op: 'remove',
+                path: '/target/api/accessToken',
             },
         ]
 


### PR DESCRIPTION
This PR updates to catch up with the back end to allow you to edit exchanges without re-entering authentication details. Ticket has minimum information (https://dhis2.atlassian.net/browse/DHIS2-18412) 

**BACKGROUND**
When the aggregate data exchange configurations were first developed, there was a limitation on the backend which meant that all of an `aggregateDataExchange.target` value had to be updated at the same point (https://dhis2.atlassian.net/browse/DHIS2-16440). As such, whenever you touched things like ID schemes, you had to reenter authentication details.

<img width="793" alt="image" src="https://github.com/user-attachments/assets/09c9408c-6820-49c9-907a-5b6e4b2823bd" />

The backend was updated to fix this, so that more specific updates by path, e.g. `target/api/url` now work, which means that we can allow users to update values without touching authentication.

Since the password, accessToken is not returned from the get for an aggregateDataExchange metadata object (for security reasons), the password/accessToken are by default empty/disabled on edit and will still require the clicking through to allow you to edit. I have also kept it such that if you edit username, you will also have to update password (this is not a backend restriction, but a logical restriction to prevent users from changing a username without changing the password). 

<img width="787" alt="image" src="https://github.com/user-attachments/assets/46e350cd-acc1-4528-8206-aa616e563150" />

**CODE NOTES**
The only real complexity with this ticket is that if the type changes from Internal to External, all of target value needs to be sent (we cannot, for example, patch `target.api.url` because it does not exist). Also, when updating to use accessToken, we need to clear out the old username/password (and vice versa) (BE does not do this automatically).

**TESTING**
I've updated the existing integration level tests to reflect the removal of the various "confirm you want to edit" buttons that had to be clicked to edit. I've also added a test there for a happy path change of authentication details. I've added some more unit-level tests for the function `getJsonPatch` which transforms the form values into the appropriate json-patch payload

I've also done a fair amount of manual testing to confirm that adding/editing works (as far as I can tell, but I might have missed something)
