### PR TITLE
fix: handle long metadata requests [DHIS2-18402]

### DIFF
--- a/src/components/edit/exchange-update/__tests__/useFetchExchange.test.js
+++ b/src/components/edit/exchange-update/__tests__/useFetchExchange.test.js
@@ -83,115 +83,103 @@ describe('getMetadataByRequest', () => {
             },
         ]
         expect(result).toEqual(EXPECTED)
-    }),
-        it('chunks ou items', () => {
-            const MOCK_VARIABLES = {
-                dx: ['dx_01', 'dx_02', 'dx_03', 'dx_04'],
-                pe: ['pe_01', 'pe_02'],
-                ou: [
-                    'ou_01',
-                    'ou_02',
-                    'ou_03',
-                    'ou_04',
-                    'ou_05',
-                    'ou_06',
-                    'ou_07',
-                    'ou_08',
-                    'ou_09',
-                    'ou_10',
-                    'ou_11',
-                    'ou_12',
-                ],
-            }
+    })
+    it('chunks ou items', () => {
+        const MOCK_VARIABLES = {
+            dx: ['dx_01', 'dx_02', 'dx_03', 'dx_04'],
+            pe: ['pe_01', 'pe_02'],
+            ou: [
+                'ou_01',
+                'ou_02',
+                'ou_03',
+                'ou_04',
+                'ou_05',
+                'ou_06',
+                'ou_07',
+                'ou_08',
+                'ou_09',
+                'ou_10',
+                'ou_11',
+                'ou_12',
+            ],
+        }
 
-            const result = getMetadataByRequest({
-                engine: MOCK_ENGINE,
-                variables: MOCK_VARIABLES,
-                index: 1,
-                chunkSize: 5,
-            })
-
-            const EXPECTED = [
-                {
-                    request: {
-                        query: 'query_name',
-                        variables: {
-                            variables: {
-                                dx: ['dx_01'],
-                                ou: [
-                                    'ou_01',
-                                    'ou_02',
-                                    'ou_03',
-                                    'ou_04',
-                                    'ou_05',
-                                ],
-                                pe: ['pe_01'],
-                            },
-                        },
-                    },
-                    index: 1,
-                },
-                {
-                    request: {
-                        query: 'query_name',
-                        variables: {
-                            variables: {
-                                dx: ['dx_01'],
-                                ou: [
-                                    'ou_06',
-                                    'ou_07',
-                                    'ou_08',
-                                    'ou_09',
-                                    'ou_10',
-                                ],
-                                pe: ['pe_01'],
-                            },
-                        },
-                    },
-                    index: 1,
-                },
-                {
-                    request: {
-                        query: 'query_name',
-                        variables: {
-                            variables: {
-                                dx: ['dx_01'],
-                                ou: ['ou_11', 'ou_12'],
-                                pe: ['pe_01'],
-                            },
-                        },
-                    },
-                    index: 1,
-                },
-                {
-                    request: {
-                        query: 'query_name',
-                        variables: {
-                            variables: {
-                                dx: ['dx_01', 'dx_02', 'dx_03', 'dx_04'],
-                                ou: ['ou_01'],
-                                pe: ['pe_01'],
-                            },
-                        },
-                    },
-                    index: 1,
-                },
-                {
-                    request: {
-                        query: 'query_name',
-                        variables: {
-                            variables: {
-                                dx: ['dx_01'],
-                                ou: ['ou_01'],
-                                pe: ['pe_01', 'pe_02'],
-                            },
-                        },
-                    },
-                    index: 1,
-                },
-            ]
-            expect(result).toEqual(EXPECTED)
+        const result = getMetadataByRequest({
+            engine: MOCK_ENGINE,
+            variables: MOCK_VARIABLES,
+            index: 1,
+            chunkSize: 5,
         })
+
+        const EXPECTED = [
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_01', 'ou_02', 'ou_03', 'ou_04', 'ou_05'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_06', 'ou_07', 'ou_08', 'ou_09', 'ou_10'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_11', 'ou_12'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01', 'dx_02', 'dx_03', 'dx_04'],
+                            ou: ['ou_01'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_01'],
+                            pe: ['pe_01', 'pe_02'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+        ]
+        expect(result).toEqual(EXPECTED)
+    })
     it('chunks mix of items', () => {
         const MOCK_VARIABLES = {
             dx: ['dx_01', 'dx_02', 'dx_03', 'dx_04', 'dx_05', 'dx_06', 'dx_07'],

--- a/src/components/edit/exchange-update/__tests__/useFetchExchange.test.js
+++ b/src/components/edit/exchange-update/__tests__/useFetchExchange.test.js
@@ -192,4 +192,136 @@ describe('getMetadataByRequest', () => {
             ]
             expect(result).toEqual(EXPECTED)
         })
+    it('chunks mix of items', () => {
+        const MOCK_VARIABLES = {
+            dx: ['dx_01', 'dx_02', 'dx_03', 'dx_04', 'dx_05', 'dx_06', 'dx_07'],
+            pe: [
+                'pe_01',
+                'pe_02',
+                'pe_03',
+                'pe_04',
+                'pe_05',
+                'pe_06',
+                'pe_07',
+                'pe_08',
+                'pe_09',
+            ],
+            ou: [
+                'ou_01',
+                'ou_02',
+                'ou_03',
+                'ou_04',
+                'ou_05',
+                'ou_06',
+                'ou_07',
+                'ou_08',
+                'ou_09',
+                'ou_10',
+                'ou_11',
+                'ou_12',
+            ],
+        }
+
+        const result = getMetadataByRequest({
+            engine: MOCK_ENGINE,
+            variables: MOCK_VARIABLES,
+            index: 1,
+            chunkSize: 5,
+        })
+
+        const EXPECTED = [
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_01', 'ou_02', 'ou_03', 'ou_04', 'ou_05'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_06', 'ou_07', 'ou_08', 'ou_09', 'ou_10'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_11', 'ou_12'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01', 'dx_02', 'dx_03', 'dx_04', 'dx_05'],
+                            ou: ['ou_01'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_06', 'dx_07'],
+                            ou: ['ou_01'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_01'],
+                            pe: ['pe_01', 'pe_02', 'pe_03', 'pe_04', 'pe_05'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_01'],
+                            pe: ['pe_06', 'pe_07', 'pe_08', 'pe_09'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+        ]
+        expect(result).toEqual(EXPECTED)
+    })
 })

--- a/src/components/edit/exchange-update/__tests__/useFetchExchange.test.js
+++ b/src/components/edit/exchange-update/__tests__/useFetchExchange.test.js
@@ -1,0 +1,195 @@
+import { getMetadataByRequest } from '../useFetchExchange.js'
+
+const MOCK_ENGINE = {
+    query: (_, variables) => ({ query: 'query_name', variables }),
+}
+
+describe('getMetadataByRequest', () => {
+    it('chunks dx items', () => {
+        const MOCK_VARIABLES = {
+            dx: [
+                'dx_01',
+                'dx_02',
+                'dx_03',
+                'dx_04',
+                'dx_05',
+                'dx_06',
+                'dx_07',
+                'dx_08',
+            ],
+            pe: ['pe_01', 'pe_02'],
+            ou: ['ou_01', 'ou_02', 'ou_03'],
+        }
+
+        const result = getMetadataByRequest({
+            engine: MOCK_ENGINE,
+            variables: MOCK_VARIABLES,
+            index: 1,
+            chunkSize: 5,
+        })
+
+        const EXPECTED = [
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_01', 'ou_02', 'ou_03'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01', 'dx_02', 'dx_03', 'dx_04', 'dx_05'],
+                            ou: ['ou_01'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_06', 'dx_07', 'dx_08'],
+                            ou: ['ou_01'],
+                            pe: ['pe_01'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+            {
+                request: {
+                    query: 'query_name',
+                    variables: {
+                        variables: {
+                            dx: ['dx_01'],
+                            ou: ['ou_01'],
+                            pe: ['pe_01', 'pe_02'],
+                        },
+                    },
+                },
+                index: 1,
+            },
+        ]
+        expect(result).toEqual(EXPECTED)
+    }),
+        it('chunks ou items', () => {
+            const MOCK_VARIABLES = {
+                dx: ['dx_01', 'dx_02', 'dx_03', 'dx_04'],
+                pe: ['pe_01', 'pe_02'],
+                ou: [
+                    'ou_01',
+                    'ou_02',
+                    'ou_03',
+                    'ou_04',
+                    'ou_05',
+                    'ou_06',
+                    'ou_07',
+                    'ou_08',
+                    'ou_09',
+                    'ou_10',
+                    'ou_11',
+                    'ou_12',
+                ],
+            }
+
+            const result = getMetadataByRequest({
+                engine: MOCK_ENGINE,
+                variables: MOCK_VARIABLES,
+                index: 1,
+                chunkSize: 5,
+            })
+
+            const EXPECTED = [
+                {
+                    request: {
+                        query: 'query_name',
+                        variables: {
+                            variables: {
+                                dx: ['dx_01'],
+                                ou: [
+                                    'ou_01',
+                                    'ou_02',
+                                    'ou_03',
+                                    'ou_04',
+                                    'ou_05',
+                                ],
+                                pe: ['pe_01'],
+                            },
+                        },
+                    },
+                    index: 1,
+                },
+                {
+                    request: {
+                        query: 'query_name',
+                        variables: {
+                            variables: {
+                                dx: ['dx_01'],
+                                ou: [
+                                    'ou_06',
+                                    'ou_07',
+                                    'ou_08',
+                                    'ou_09',
+                                    'ou_10',
+                                ],
+                                pe: ['pe_01'],
+                            },
+                        },
+                    },
+                    index: 1,
+                },
+                {
+                    request: {
+                        query: 'query_name',
+                        variables: {
+                            variables: {
+                                dx: ['dx_01'],
+                                ou: ['ou_11', 'ou_12'],
+                                pe: ['pe_01'],
+                            },
+                        },
+                    },
+                    index: 1,
+                },
+                {
+                    request: {
+                        query: 'query_name',
+                        variables: {
+                            variables: {
+                                dx: ['dx_01', 'dx_02', 'dx_03', 'dx_04'],
+                                ou: ['ou_01'],
+                                pe: ['pe_01'],
+                            },
+                        },
+                    },
+                    index: 1,
+                },
+                {
+                    request: {
+                        query: 'query_name',
+                        variables: {
+                            variables: {
+                                dx: ['dx_01'],
+                                ou: ['ou_01'],
+                                pe: ['pe_01', 'pe_02'],
+                            },
+                        },
+                    },
+                    index: 1,
+                },
+            ]
+            expect(result).toEqual(EXPECTED)
+        })
+})

--- a/src/components/edit/exchange-update/useFetchExchange.js
+++ b/src/components/edit/exchange-update/useFetchExchange.js
@@ -43,7 +43,7 @@ const VISUALIZATIONS_QUERY = {
     },
 }
 
-const ANALYTICS_QUERY = {
+export const ANALYTICS_QUERY = {
     metadata: {
         resource: 'analytics',
         params: ({ ou, dx, pe, inputIdScheme }) => ({
@@ -58,22 +58,22 @@ const ANALYTICS_QUERY = {
     },
 }
 
-const CHUNK_SIZE = 50
-
-const getChunkedAnalyticsQueries = ({ engine, variables, index }) => {
+const getChunkedAnalyticsQueries = ({
+    engine,
+    variables,
+    index,
+    chunkSize,
+}) => {
     const { ou, dx, pe } = variables
 
     const chunks = []
     for (const variableType of ['ou', 'dx', 'pe']) {
-        for (let i = 0; i < variables[variableType].length; i += CHUNK_SIZE) {
+        for (let i = 0; i < variables[variableType].length; i += chunkSize) {
             chunks.push({
                 dx: [dx[0]],
                 ou: [ou[0]],
                 pe: [pe[0]],
-                [variableType]: variables[variableType].slice(
-                    i,
-                    i + CHUNK_SIZE
-                ),
+                [variableType]: variables[variableType].slice(i, i + chunkSize),
             })
         }
     }
@@ -86,12 +86,22 @@ const getChunkedAnalyticsQueries = ({ engine, variables, index }) => {
     }))
 }
 
-const getMetadataByRequest = ({ engine, variables, index }) => {
+export const getMetadataByRequest = ({
+    engine,
+    variables,
+    index,
+    chunkSize,
+}) => {
     if (
         variables.ou.length + variables.pe.length + variables.dx.length >
-        CHUNK_SIZE
+        chunkSize
     ) {
-        return getChunkedAnalyticsQueries({ engine, variables, index })
+        return getChunkedAnalyticsQueries({
+            engine,
+            variables,
+            index,
+            chunkSize,
+        })
     }
     return [
         {
@@ -126,6 +136,7 @@ export const useFetchExchange = () => {
                             engine,
                             variables: { ou, dx, pe, inputIdScheme },
                             index,
+                            chunkSize: 50,
                         })
                     })
                     .flat()


### PR DESCRIPTION
**Background:** when opening a exchange for editing, a request is sent to analytics to retrieve metadata for the underlying items of the exchange. However, when a request contains many items, the URL can become too long.  (see https://dhis2.atlassian.net/browse/DHIS2-18402)
 
This PR chunks requests so if there are more than 50 dx,ou,pe they will be chunked up such that an individual request will only contain 50 of one type (e.g. dx) (and if chunking by dx, 1 ou and 1 pe to make the analytics request work).

**Testing:** I've added a unit test for the function to define the metadata requests. Setting up a more integration-level test when opening the exchange is a bit labour intensive in the sense that we'd have to define more behaviour on a custom data provider and I don't think that's worth it for this change.

I've also done some manual testing (see ticket for a metadata file that can add an adx definition with all the 507 NUMBER type data elements of Sierra Leone database as dx items)